### PR TITLE
ll-19 fix(subscriptions): make publishLog protocol-compliant for graphql-ws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,18 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@graphql-tools/schema": "^10.0.25",
         "@prisma/client": "^6.16.3",
         "amqplib": "^0.10.9",
         "apollo-server": "^3.13.0",
         "bcryptjs": "^3.0.2",
         "graphql": "^16.11.0",
+        "graphql-subscriptions": "^3.0.0",
+        "graphql-ws": "^5.16.2",
         "jsonwebtoken": "^9.0.2",
-        "prisma": "^6.16.3"
+        "prisma": "^6.16.3",
+        "subscriptions-transport-ws": "^0.11.0",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "@types/amqplib": "^0.10.7",
@@ -24,6 +29,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.6.2",
+        "@types/ws": "^8.18.1",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.4",
         "ts-node": "^10.9.2",
@@ -775,23 +781,33 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
-      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.1.tgz",
+      "integrity": "sha512-BJ5/7Y7GOhTuvzzO5tSBFL4NGr7PVqTJY3KeIDlVTT8YLcTXtBR+hlrC3uyEym7Ragn+zyWdHeJ9ev+nRX1X2w==",
       "dependencies": {
-        "@graphql-tools/utils": "8.9.0",
+        "@graphql-tools/utils": "^10.9.1",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.9.1.tgz",
+      "integrity": "sha512-B1wwkXk9UvU7LCBkPs8513WxOQ2H8Fo5p8HR1+Id9WmYE5+bd51vqN+MbrqvWczHCH2gwkREgHJN88tE0n1FCw==",
       "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -846,25 +862,34 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
-      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
+      "version": "10.0.25",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.25.tgz",
+      "integrity": "sha512-/PqE8US8kdQ7lB9M5+jlW8AyVjRGCKU7TSktuW3WNKSKmDO0MK1wakvb5gGdyT49MjAIb4a3LWxIpwo5VygZuw==",
       "dependencies": {
-        "@graphql-tools/merge": "8.3.1",
-        "@graphql-tools/utils": "8.9.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
+        "@graphql-tools/merge": "^9.1.1",
+        "@graphql-tools/utils": "^10.9.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.9.1.tgz",
+      "integrity": "sha512-B1wwkXk9UvU7LCBkPs8513WxOQ2H8Fo5p8HR1+Id9WmYE5+bd51vqN+MbrqvWczHCH2gwkREgHJN88tE0n1FCw==",
       "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -1809,6 +1834,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -2080,6 +2114,17 @@
         "win32"
       ]
     },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2285,6 +2330,43 @@
       },
       "peerDependencies": {
         "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/@graphql-tools/merge": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
+      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
+      "dependencies": {
+        "@graphql-tools/utils": "8.9.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/@graphql-tools/schema": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
+      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
+      "dependencies": {
+        "@graphql-tools/merge": "8.3.1",
+        "@graphql-tools/utils": "8.9.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/@graphql-tools/utils": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/apollo-server-env": {
@@ -2521,6 +2603,11 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
+    },
+    "node_modules/backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3030,6 +3117,17 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3158,6 +3256,14 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -3320,6 +3426,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -3727,6 +3838,14 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-subscriptions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-3.0.0.tgz",
+      "integrity": "sha512-kZCdevgmzDjGAOqH7GlDmQXYAkuHoKpMlJrqF40HMPhUhM5ZWSFSxCwD/nSi6AkaijmMfsFhoJRGJ27UseCvRA==",
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
@@ -3739,6 +3858,17 @@
       },
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/handlebars": {
@@ -4090,6 +4220,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -6039,6 +6174,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/subscriptions-transport-ws": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
+    "node_modules/subscriptions-transport-ws/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6049,6 +6220,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/synckit": {
@@ -6685,6 +6864,26 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xss": {

--- a/package.json
+++ b/package.json
@@ -20,19 +20,25 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.6.2",
+    "@types/ws": "^8.18.1",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@graphql-tools/schema": "^10.0.25",
     "@prisma/client": "^6.16.3",
     "amqplib": "^0.10.9",
     "apollo-server": "^3.13.0",
     "bcryptjs": "^3.0.2",
     "graphql": "^16.11.0",
+    "graphql-subscriptions": "^3.0.0",
+    "graphql-ws": "^5.16.2",
     "jsonwebtoken": "^9.0.2",
-    "prisma": "^6.16.3"
+    "prisma": "^6.16.3",
+    "subscriptions-transport-ws": "^0.11.0",
+    "ws": "^8.18.3"
   },
   "type": "module"
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,32 @@
+import { createClient } from "graphql-ws";
+import WebSocket from "ws";
+
+const client = createClient({
+  url: "ws://localhost:4001/graphql",
+  webSocketImpl: WebSocket,
+  connectionAckWaitTimeout: 5000, // Wait max 5s for server ack
+});
+console.log("👂 Attempting to connect to subscription server...");
+
+client.subscribe(
+  {
+    query: `
+      subscription {
+        newLog {
+          id
+          service
+          level
+          message
+          timestamp
+        }
+      }
+    `,
+  },
+  {
+    next: (data) => console.log("📡 New log received:", data.data?.newLog),
+    error: (err) => {
+      console.error("❌ Subscription error:", err);
+    },
+    complete: () => console.log("✅ Subscription complete"),
+  }
+);

--- a/src/graphql/pubsub.ts
+++ b/src/graphql/pubsub.ts
@@ -1,0 +1,3 @@
+import { PubSub } from "graphql-subscriptions";
+
+export const pubsub = new PubSub();

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -29,17 +29,14 @@ export const logsQuery = {
     
     const filters: any = {};
 
-    // Apply service filter
     if (args.service) {
       filters.service = args.service;
     }
 
-    // Apply level filter
     if (args.level) {
       filters.level = args.level;
     }
 
-    // Apply timestamp range filter
     if (args.from && args.to) {
       filters.timestamp = {
         gte: new Date(args.from),
@@ -51,7 +48,6 @@ export const logsQuery = {
       filters.timestamp = { lte: new Date(args.to) };
     }
 
-    // Query database using Prisma
     const logs = await prisma.log.findMany({
       where: filters,
       orderBy: { timestamp: "desc" },

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
 import { addLogToQueue, addLog, register, login } from './mutations.ts';
 import { logsQuery } from "./queries.ts";
+import { newLogSubscription } from "./subscriptions.ts";
 
 const Query = new GraphQLObjectType({
   name: "Query",
@@ -23,7 +24,15 @@ const Mutation = new GraphQLObjectType({
   },
 });
 
+const Subscription = new GraphQLObjectType({
+  name: "Subscription",
+  fields: {
+    newLog: newLogSubscription,
+  },
+});
+
 export const schema = new GraphQLSchema({
     query: Query,
     mutation: Mutation,
+    subscription: Subscription,
 });

--- a/src/graphql/subscriptions.ts
+++ b/src/graphql/subscriptions.ts
@@ -1,0 +1,60 @@
+import { LogType } from "./types.ts";
+import { WebSocket, WebSocketServer } from "ws";
+import { useServer } from "graphql-ws/lib/use/ws";
+import { GraphQLSchema } from "graphql";
+
+const subscribers: ((log: any) => void)[] = [];
+
+export function publishLog(log: any) {
+  const count = subscribers.length;
+  subscribers.forEach((resolve) => resolve(log));
+  subscribers.length = 0;
+  // wsServer?.publishLog?.(log);
+
+  console.log(`[publishLog] Sent log to ${count} in-process subscribers`, log);
+  return { delivered: count, log };
+}
+
+export const newLogSubscription = {
+  type: LogType,
+  subscribe: (_: any, __: any) => {
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        while (true) {
+          const log = await new Promise((resolve) => subscribers.push(resolve));
+          yield { newLog: log };
+        }
+      },
+    };
+  },
+  resolve: (payload: any) => payload.newLog,
+};
+
+type WsServerWithPublish = ReturnType<typeof useServer> & { publishLog?: (log: any) => void };
+let wsServer: WsServerWithPublish | undefined;
+
+export function setupWebSocketServer(schema: GraphQLSchema, port = 4001) {
+  const wss = new WebSocketServer({
+    port,
+    path: "/graphql",
+  });
+
+  const server = useServer({ schema }, wss);
+  (server as WsServerWithPublish).publishLog = (log: any) => {
+    // wss.clients.forEach((client) => {
+    //   if (client.readyState === WebSocket.OPEN) {
+    //     try {
+    //       client.send(JSON.stringify({ type: "next", payload: { data: { newLog: log } } }));
+    //     } catch (err) {
+    //       console.error("Failed to send log to client", err);
+    //     }
+    //   }
+    // });
+    subscribers.forEach((resolve) => resolve(log));
+  };
+
+  wsServer = server as WsServerWithPublish;
+  wsServer = server as any;
+  console.log("🟢 WebSocket subscription server ready at /graphql");
+  return wsServer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ApolloServer, gql } from "apollo-server";
 import jwt from "jsonwebtoken";
 import { schema } from "./graphql/schema.ts";
-import { connectRabbitMQ, getChannel } from "./rabbitmq.js";
+import { connectRabbitMQ } from "./rabbitmq.js";
 
 const SECRET_KEY = "supersecretkey123";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "ES2020",
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -9,5 +9,5 @@
     "outDir": "dist",
     "allowImportingTsExtensions": true,
   },
-  "include": ["src"]
+  "include": ["src", "wiki/wsServer-dis.ts"]
 }


### PR DESCRIPTION
- Removed manual WebSocket message sending that lacked subscription IDs
- Updated publishLog to push logs via in-process async iterator
- Ensures subscription messages are delivered correctly to clients
- Fixes "next message expects 'id'" error in subscription client